### PR TITLE
Update UnitUtils.h with std::string

### DIFF
--- a/src/Framework/Utils/UnitUtils.h
+++ b/src/Framework/Utils/UnitUtils.h
@@ -19,6 +19,9 @@
 #ifndef _UNIT_UTILS_H_
 #define _UNIT_UTILS_H_
 
+#include <string>
+using std::string;
+
 namespace genie {
 namespace utils {
 


### PR DESCRIPTION
Import and add namespace for std::string to UnitUtils.h. This was done some time back on the main GENIE repo by R. Hatcher: https://github.com/GENIE-MC/Generator/commit/5414123b27c5748f3c328d20d40c489e7f5f7fe5. There are more changes in his commit which may also be good to do. I needed to specify std::string in order to build successfully for docker container. 